### PR TITLE
make middleware work with new-style for Django 1.10+

### DIFF
--- a/redirect_urls/middleware.py
+++ b/redirect_urls/middleware.py
@@ -1,11 +1,30 @@
 from django.core.urlresolvers import Resolver404
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+    is_compatible_with_new_style = False
+else:
+    is_compatible_with_new_style = True
 
 from redirect_urls.utils import get_resolver
 
 
-class RedirectsMiddleware(object):
-    def __init__(self, resolver=None):
+class RedirectsMiddleware(MiddlewareMixin):
+
+    @classmethod
+    def for_test(cls, get_response=None, resolver=None):
+        middleware = cls(get_response or (lambda req: None), resolver)
+        if not is_compatible_with_new_style:
+            return middleware.process_request
+        return middleware
+
+    def __init__(self, get_response=None, resolver=None):
         self.resolver = resolver or get_resolver()
+        if is_compatible_with_new_style:
+            super(RedirectsMiddleware, self).__init__(get_response)
+        else:
+            super(RedirectsMiddleware, self).__init__()
 
     def process_request(self, request):
         try:

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -91,16 +91,15 @@ class TestNoRedirectUrlPattern(TestCase):
             no_redirect(r'^iam/the/walrus/$'),
             redirect(r'^iam/the/.*/$', '/coo/coo/cachoo/'),
         ])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertIsNone(resp)
 
         # including locale
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/pt-BR/iam/the/walrus/'))
+        resp = middleware(self.rf.get('/pt-BR/iam/the/walrus/'))
         self.assertIsNone(resp)
 
-        resp = middleware.process_request(self.rf.get('/iam/the/marmot/'))
+        resp = middleware(self.rf.get('/iam/the/marmot/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/coo/coo/cachoo/')
 
@@ -112,16 +111,16 @@ class TestNoRedirectUrlPattern(TestCase):
             redirect(r'^iam/the/walrus/$', '/coo/coo/cachoo/'),
             no_redirect(r'^iam/the/walrus/$', re_flags='i'),
         ])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/IAm/The/Walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/IAm/The/Walrus/'))
         self.assertIsNone(resp)
 
         # also with locale
-        resp = middleware.process_request(self.rf.get('/es-ES/Iam/The/Walrus/'))
+        resp = middleware(self.rf.get('/es-ES/Iam/The/Walrus/'))
         self.assertIsNone(resp)
 
         # sanity check
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/coo/coo/cachoo/')
 
@@ -281,8 +280,8 @@ class TestRedirectUrlPattern(TestCase):
         Should be able to capture info from URL and use in redirection.
         """
         resolver = get_resolver([redirect(r'^iam/the/(?P<name>.+)/$', '/donnie/the/{name}/')])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/donnie/the/walrus/')
 
@@ -292,8 +291,8 @@ class TestRedirectUrlPattern(TestCase):
         """
         resolver = get_resolver([redirect(r'^iam/the/(?P<name>.+)/$',
                                           '/donnie/the/{name}/')])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/pt-BR/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/pt-BR/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/pt-BR/donnie/the/walrus/')
 
@@ -303,8 +302,8 @@ class TestRedirectUrlPattern(TestCase):
         """
         resolver = get_resolver([redirect(r'^iam/the/(?P<name>.+)/$',
                                           '/donnie/the/{name}/')])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/donnie/the/walrus/')
 
@@ -314,8 +313,8 @@ class TestRedirectUrlPattern(TestCase):
         """
         resolver = get_resolver([redirect(r'^iam/the/(?P<name>.+)/$',
                                           '/donnie/the/{name}/', prepend_locale=False)])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/zh-TW/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/zh-TW/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/donnie/the/walrus/')
 
@@ -329,8 +328,8 @@ class TestRedirectUrlPattern(TestCase):
         """
         resolver = get_resolver([redirect(r'^iam/the/(.+)/$', '/donnie/the/{}/',
                                           locale_prefix=False)])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/donnie/the/walrus/')
 
@@ -340,8 +339,8 @@ class TestRedirectUrlPattern(TestCase):
         """
         resolver = get_resolver([redirect(r'^iam/the(/.+)?/$', '/donnie/the{}/',
                                           locale_prefix=False)])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/iam/the/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/iam/the/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/donnie/the/')
 
@@ -353,18 +352,18 @@ class TestRedirectUrlPattern(TestCase):
             redirect(r'^iam/the/walrus/$', '/coo/coo/cachoo/'),
             redirect(r'^iam/the/walrus/$', '/dammit/donnie/', re_flags='i'),
         ])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/IAm/The/Walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/IAm/The/Walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/dammit/donnie/')
 
         # also with locale
-        resp = middleware.process_request(self.rf.get('/es-ES/Iam/The/Walrus/'))
+        resp = middleware(self.rf.get('/es-ES/Iam/The/Walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/es-ES/dammit/donnie/')
 
         # sanity check
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/coo/coo/cachoo/')
 
@@ -378,9 +377,9 @@ class TestRedirectUrlPattern(TestCase):
         """
         resolver = get_resolver([redirect(r'^editor/(?P<page>.*)$',
                                           'http://www-archive.mozilla.org/editor/{page}')])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/editor/midasdemo/securityprefs.html'
-                                                      '%3C/span%3E%3C/a%3E%C2%A0'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/editor/midasdemo/securityprefs.html'
+                                      '%3C/span%3E%3C/a%3E%C2%A0'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], 'http://www-archive.mozilla.org/editor/midasdemo/'
                                            'securityprefs.html%C2%A0')
@@ -394,11 +393,11 @@ class TestRedirectUrlPattern(TestCase):
             redirect(r'^iam/the/walrus/$', '/coo/coo/cachoo/'),
             redirect(r'^iam/the/ape-man/$', 'https://example.com/egg-man/'),
         ])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/iam/the/walrus/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/iam/the/walrus/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], '/coo/coo/cachoo/')
-        resp = middleware.process_request(self.rf.get('/iam/the/ape-man/'))
+        resp = middleware(self.rf.get('/iam/the/ape-man/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['Location'], 'https://example.com/egg-man/')
         reverse_mock.assert_not_called()
@@ -408,6 +407,6 @@ class TestRedirectUrlPattern(TestCase):
         resolver = get_resolver([
             redirect(r'^(.+)/$', '/{}/', locale_prefix=False),
         ])
-        middleware = RedirectsMiddleware(resolver)
-        resp = middleware.process_request(self.rf.get('/%2fexample.com/'))
+        middleware = RedirectsMiddleware.for_test(resolver=resolver)
+        resp = middleware(self.rf.get('/%2fexample.com/'))
         self.assertEqual(resp['Location'], '/example.com/')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -12,7 +12,7 @@ patterns = [
     redirect(r'^dude/already/10th/', '/far/out/'),
     redirect(r'^walter/prior/restraint/', '/finishes/coffee/'),
 ]
-middleware = RedirectsMiddleware(get_resolver(patterns))
+middleware = RedirectsMiddleware.for_test(resolver=get_resolver(patterns))
 
 
 class TestRedirectsMiddleware(TestCase):
@@ -20,10 +20,10 @@ class TestRedirectsMiddleware(TestCase):
         self.rf = RequestFactory()
 
     def test_finds_and_uses_redirect(self):
-        resp = middleware.process_request(self.rf.get('/walter/prior/restraint/'))
+        resp = middleware(self.rf.get('/walter/prior/restraint/'))
         self.assertEqual(resp.status_code, 301)
         self.assertEqual(resp['location'], '/finishes/coffee/')
 
     def test_no_redirect_match(self):
-        resp = middleware.process_request(self.rf.get('/donnie/out/element/'))
+        resp = middleware(self.rf.get('/donnie/out/element/'))
         self.assertIsNone(resp)


### PR DESCRIPTION
Hello @pmac! This PR updates `RedirectsMiddleware` to be compatible with the new-style MIDDLEWARE setting introduced in Django 1.10 while remaining compatible with the old-style MIDDLEWARE_CLASSES setting.